### PR TITLE
Enable the `run_async=False` option for the `InferenceClient`.

### DIFF
--- a/tests/common_fixtures.py
+++ b/tests/common_fixtures.py
@@ -1,0 +1,16 @@
+import os
+
+import pytest
+
+MODEL_NAME = os.environ.get("MODEL_NAME", "sample")
+TRITON_HOST = os.environ.get("TRITON_HOST", "localhost")
+TRITON_HTTP = os.environ.get("TRITON_HTTP", "8100")
+TRITON_GRPC = os.environ.get("TRITON_GRPC", "8101")
+
+
+@pytest.fixture(params=[("http", TRITON_HTTP, True), ("grpc", TRITON_GRPC, True), ("grpc", TRITON_GRPC, False)])
+def config(request):
+    """
+    Returns a tuple of (protocol, port, run_async)
+    """
+    return request.param

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -8,20 +8,20 @@ from tritony import InferenceClient
 
 MODEL_NAME = os.environ.get("MODEL_NAME", "sample")
 TRITON_HOST = os.environ.get("TRITON_HOST", "localhost")
-TRITON_HTTP = os.environ.get("TRITON_HTTP", "8000")
-TRITON_GRPC = os.environ.get("TRITON_GRPC", "8001")
+TRITON_HTTP = os.environ.get("TRITON_HTTP", "8100")
+TRITON_GRPC = os.environ.get("TRITON_GRPC", "8101")
 
 
-@pytest.fixture(params=[("http", TRITON_HTTP), ("grpc", TRITON_GRPC)])
+@pytest.fixture(params=[("http", TRITON_HTTP, True), ("grpc", TRITON_GRPC, True), ("grpc", TRITON_GRPC, False)])
 def protocol_and_port(request):
     return request.param
 
 
 def test_basics(protocol_and_port):
-    protocol, port = protocol_and_port
-    print(f"Testing {protocol}")
+    protocol, port, run_async = protocol_and_port
+    print(f"Testing {protocol} with run_async={run_async}")
 
-    client = InferenceClient.create_with(MODEL_NAME, f"{TRITON_HOST}:{port}", protocol=protocol)
+    client = InferenceClient.create_with(MODEL_NAME, f"{TRITON_HOST}:{port}", protocol=protocol, run_async=run_async)
 
     sample = np.random.rand(1, 100).astype(np.float32)
     result = client(sample)
@@ -32,10 +32,12 @@ def test_basics(protocol_and_port):
 
 
 def test_batching(protocol_and_port):
-    protocol, port = protocol_and_port
-    print(f"{__name__}, Testing {protocol}")
+    protocol, port, run_async = protocol_and_port
+    print(f"{__name__}, Testing {protocol} with run_async={run_async}")
 
-    client = InferenceClient.create_with("sample_autobatching", f"{TRITON_HOST}:{port}", protocol=protocol)
+    client = InferenceClient.create_with(
+        "sample_autobatching", f"{TRITON_HOST}:{port}", protocol=protocol, run_async=run_async
+    )
 
     sample = np.random.rand(100, 100).astype(np.float32)
     # client automatically makes sub batches with (50, 2, 100)
@@ -44,10 +46,12 @@ def test_batching(protocol_and_port):
 
 
 def test_exception(protocol_and_port):
-    protocol, port = protocol_and_port
-    print(f"{__name__}, Testing {protocol}")
+    protocol, port, run_async = protocol_and_port
+    print(f"{__name__}, Testing {protocol} with run_async={run_async}")
 
-    client = InferenceClient.create_with("sample_autobatching", f"{TRITON_HOST}:{port}", protocol=protocol)
+    client = InferenceClient.create_with(
+        "sample_autobatching", f"{TRITON_HOST}:{port}", protocol=protocol, run_async=run_async
+    )
 
     sample = np.random.rand(100, 100, 100).astype(np.float32)
     # client automatically makes sub batches with (50, 2, 100)

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -1,24 +1,15 @@
-import os
-
 import grpc
 import numpy as np
-import pytest
 
 from tritony import InferenceClient
 
-MODEL_NAME = os.environ.get("MODEL_NAME", "sample")
-TRITON_HOST = os.environ.get("TRITON_HOST", "localhost")
-TRITON_HTTP = os.environ.get("TRITON_HTTP", "8100")
-TRITON_GRPC = os.environ.get("TRITON_GRPC", "8101")
+from .common_fixtures import MODEL_NAME, TRITON_HOST, config
+
+__all__ = ["config"]
 
 
-@pytest.fixture(params=[("http", TRITON_HTTP, True), ("grpc", TRITON_GRPC, True), ("grpc", TRITON_GRPC, False)])
-def protocol_and_port(request):
-    return request.param
-
-
-def test_basics(protocol_and_port):
-    protocol, port, run_async = protocol_and_port
+def test_basics(config):
+    protocol, port, run_async = config
     print(f"Testing {protocol} with run_async={run_async}")
 
     client = InferenceClient.create_with(MODEL_NAME, f"{TRITON_HOST}:{port}", protocol=protocol, run_async=run_async)
@@ -31,8 +22,8 @@ def test_basics(protocol_and_port):
     assert np.isclose(result, sample).all()
 
 
-def test_batching(protocol_and_port):
-    protocol, port, run_async = protocol_and_port
+def test_batching(config):
+    protocol, port, run_async = config
     print(f"{__name__}, Testing {protocol} with run_async={run_async}")
 
     client = InferenceClient.create_with(
@@ -45,8 +36,8 @@ def test_batching(protocol_and_port):
     assert np.isclose(result, sample).all()
 
 
-def test_exception(protocol_and_port):
-    protocol, port, run_async = protocol_and_port
+def test_exception(config):
+    protocol, port, run_async = config
     print(f"{__name__}, Testing {protocol} with run_async={run_async}")
 
     client = InferenceClient.create_with(

--- a/tests/test_model_call.py
+++ b/tests/test_model_call.py
@@ -1,21 +1,11 @@
-import os
-
 import numpy as np
-import pytest
 
 from tritony import InferenceClient
 
-TRITON_HOST = os.environ.get("TRITON_HOST", "localhost")
-TRITON_HTTP = os.environ.get("TRITON_HTTP", "8100")
-TRITON_GRPC = os.environ.get("TRITON_GRPC", "8101")
-
+from .common_fixtures import TRITON_HOST, config
 
 EPSILON = 1e-8
-
-
-@pytest.fixture(params=[("http", TRITON_HTTP, True), ("grpc", TRITON_GRPC, True), ("grpc", TRITON_GRPC, False)])
-def protocol_and_port(request):
-    return request.param
+__all__ = ["config"]
 
 
 def get_client(protocol, port, run_async, model_name):
@@ -23,8 +13,8 @@ def get_client(protocol, port, run_async, model_name):
     return InferenceClient.create_with(model_name, f"{TRITON_HOST}:{port}", protocol=protocol, run_async=run_async)
 
 
-def test_swithcing(protocol_and_port):
-    client = get_client(*protocol_and_port, model_name="sample")
+def test_swithcing(config):
+    client = get_client(*config, model_name="sample")
 
     sample = np.random.rand(1, 100).astype(np.float32)
     result = client(sample)
@@ -35,16 +25,16 @@ def test_swithcing(protocol_and_port):
     assert np.isclose(result, sample).all()
 
 
-def test_with_input_name(protocol_and_port):
-    client = get_client(*protocol_and_port, model_name="sample")
+def test_with_input_name(config):
+    client = get_client(*config, model_name="sample")
 
     sample = np.random.rand(100, 100).astype(np.float32)
     result = client({client.default_model_spec.model_input[0].name: sample})
     assert np.isclose(result, sample).all()
 
 
-def test_with_parameters(protocol_and_port):
-    client = get_client(*protocol_and_port, model_name="sample")
+def test_with_parameters(config):
+    client = get_client(*config, model_name="sample")
 
     sample = np.random.rand(1, 100).astype(np.float32)
     ADD_VALUE = 1
@@ -53,8 +43,8 @@ def test_with_parameters(protocol_and_port):
     assert np.isclose(result[0], sample[0] + ADD_VALUE).all()
 
 
-def test_with_optional(protocol_and_port):
-    client = get_client(*protocol_and_port, model_name="sample_optional")
+def test_with_optional(config):
+    client = get_client(*config, model_name="sample_optional")
 
     sample = np.random.rand(1, 100).astype(np.float32)
 
@@ -71,8 +61,8 @@ def test_with_optional(protocol_and_port):
     assert np.isclose(result[0], sample[0] - OPTIONAL_SUB_VALUE, rtol=EPSILON).all()
 
 
-def test_reload_model_spec(protocol_and_port):
-    client = get_client(*protocol_and_port, model_name="sample_autobatching")
+def test_reload_model_spec(config):
+    client = get_client(*config, model_name="sample_autobatching")
     # force to change max_batch_size
     client.default_model_spec.max_batch_size = 4
 

--- a/tests/test_model_call.py
+++ b/tests/test_model_call.py
@@ -6,21 +6,21 @@ import pytest
 from tritony import InferenceClient
 
 TRITON_HOST = os.environ.get("TRITON_HOST", "localhost")
-TRITON_HTTP = os.environ.get("TRITON_HTTP", "8000")
-TRITON_GRPC = os.environ.get("TRITON_GRPC", "8001")
+TRITON_HTTP = os.environ.get("TRITON_HTTP", "8100")
+TRITON_GRPC = os.environ.get("TRITON_GRPC", "8101")
 
 
 EPSILON = 1e-8
 
 
-@pytest.fixture(params=[("http", TRITON_HTTP), ("grpc", TRITON_GRPC)])
+@pytest.fixture(params=[("http", TRITON_HTTP, True), ("grpc", TRITON_GRPC, True), ("grpc", TRITON_GRPC, False)])
 def protocol_and_port(request):
     return request.param
 
 
-def get_client(protocol, port, model_name):
-    print(f"Testing {protocol}", flush=True)
-    return InferenceClient.create_with(model_name, f"{TRITON_HOST}:{port}", protocol=protocol)
+def get_client(protocol, port, run_async, model_name):
+    print(f"Testing {protocol} with run_async={run_async}", flush=True)
+    return InferenceClient.create_with(model_name, f"{TRITON_HOST}:{port}", protocol=protocol, run_async=run_async)
 
 
 def test_swithcing(protocol_and_port):
@@ -79,8 +79,3 @@ def test_reload_model_spec(protocol_and_port):
     sample = np.random.rand(8, 100).astype(np.float32)
     result = client(sample)
     assert np.isclose(result, sample).all()
-
-
-if __name__ == "__main__":
-    test_with_parameters(("grpc", "8101"))
-    test_with_optional(("grpc", "8101"))

--- a/tritony/helpers.py
+++ b/tritony/helpers.py
@@ -4,7 +4,7 @@ import json
 from collections import defaultdict
 from enum import Enum
 from types import SimpleNamespace
-from typing import Any, Optional, Union
+from typing import Any
 
 import attrs
 from attrs import define
@@ -18,7 +18,7 @@ class TritonProtocol(Enum):
     http = "http"
 
 
-COMPRESSION_ALGORITHM_MAP = defaultdict(int)
+COMPRESSION_ALGORITHM_MAP: dict[str, int] = defaultdict(int)
 COMPRESSION_ALGORITHM_MAP.update({"deflate": 1, "gzip": 2})
 
 
@@ -83,13 +83,13 @@ class TritonClientFlag:
     concurrency: int = 6  # only for TritonProtocol.http client
     verbose: bool = False
     input_dims: int = 1
-    compression_algorithm: Optional[str] = None
+    compression_algorithm: str | None = None
     ssl: bool = False
 
 
 def init_triton_client(
     flag: TritonClientFlag,
-) -> Union[grpcclient.InferenceServerClient, httpclient.InferenceServerClient]:
+) -> grpcclient.InferenceServerClient | httpclient.InferenceServerClient:
     assert not (
         flag.streaming and not (flag.protocol is TritonProtocol.grpc)
     ), "Streaming is only allowed with gRPC protocol"
@@ -107,7 +107,7 @@ def init_triton_client(
 
 
 def get_triton_client(
-    triton_client: Union[grpcclient.InferenceServerClient, httpclient.InferenceServerClient],
+    triton_client: grpcclient.InferenceServerClient | httpclient.InferenceServerClient,
     model_name: str,
     model_version: str,
     protocol: TritonProtocol,


### PR DESCRIPTION
## Intro
The `InferenceClient` did not have functionality implemented for `run_async=False`. This PR addresses that by implementing the feature and updating unit tests to ensure it.  
If there were no plans for implementing this feature yet, I hope this PR would be helpful 😀

## Changes
- `InferenceClient._call_request`
  - This is a new pipeline corresponding to the `_call_async`.
  - I'm not sure it is structurally identical, but it has been implemented to follow the same logic of `_call_async`.
- `tests/*.py`
  - Updated port numbers to match those in `bin/run_triton_tritony_sample.sh`.
  - Added a new test parameter `run_async`.

## Tests
```bash
pytest -s --cov-report term-missing --cov=tritony tests
```

<details>
<summary> My test outputs</summary>

```python
=================================================================================== test session starts ====================================================================================
platform darwin -- Python 3.10.13, pytest-7.4.3, pluggy-1.3.0
Matplotlib: 3.8.2
Freetype: 2.6.1
rootdir: /Users/Sangwon/git/tritony
plugins: cov-4.1.0, mpl-0.16.1, xdist-3.5.0
collected 24 items                                                                                                                                                                         

tests/test_connect.py Testing http with run_async=True
.Testing grpc with run_async=True
.Testing grpc with run_async=False
.tests.test_connect, Testing http with run_async=True
.tests.test_connect, Testing grpc with run_async=True
.tests.test_connect, Testing grpc with run_async=False
.tests.test_connect, Testing http with run_async=True
<class 'RuntimeError'>
.tests.test_connect, Testing grpc with run_async=True
.tests.test_connect, Testing grpc with run_async=False
.
tests/test_model_call.py Testing http with run_async=True
.Testing grpc with run_async=True
.Testing grpc with run_async=False
.Testing http with run_async=True
.Testing grpc with run_async=True
.Testing grpc with run_async=False
.Testing http with run_async=True
.Testing grpc with run_async=True
.Testing grpc with run_async=False
.Testing http with run_async=True
.Testing grpc with run_async=True
.Testing grpc with run_async=False
.Testing http with run_async=True
.Testing grpc with run_async=True
.Testing grpc with run_async=False
.

===================================================================================== warnings summary =====================================================================================
tritony/tools.py:23
  /Users/Sangwon/git/tritony/tritony/tools.py:23: UserWarning: tritonclient[all]>=2.34.0
    warnings.warn(UserWarning("tritonclient[all]>=2.34.0"))

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html

--------- coverage: platform darwin, python 3.10.13-final-0 ----------
Name                  Stmts   Miss  Cover   Missing
---------------------------------------------------
tritony/__init__.py       5      0   100%
tritony/helpers.py       71      0   100%
tritony/tools.py        243     12    95%   118-119, 135-137, 152, 175-177, 434-435, 495
tritony/version.py        1      0   100%
---------------------------------------------------
TOTAL                   320     12    96%

======================================================================== 24 passed, 1 warning in 377.57s (0:06:17) =========================================================================
```

</details>

